### PR TITLE
feat(lib): add plugin that can execute arbitrary shell commands from manifest

### DIFF
--- a/src/__tests__/unit/lib/exec-shell-command/index.test.ts
+++ b/src/__tests__/unit/lib/exec-shell-command/index.test.ts
@@ -1,0 +1,69 @@
+import {ShellExecCommand} from '../../../../lib';
+import * as execShell from '../../../../lib/shell-exec-command';
+describe('lib/exec-shell-command', () => {
+  describe('ExecShellCommand:', () => {
+    describe('init ExecShellCommand: ', () => {
+      it('initalizes ExecShellCommand with required properties', () => {
+        const timerStart = ShellExecCommand();
+
+        expect.assertions(2);
+
+        expect(timerStart).toHaveProperty('metadata');
+        expect(timerStart).toHaveProperty('execute');
+      });
+    });
+
+    describe('execute():', () => {
+      it('executes the given command and writes stdout to input', async () => {
+        const testString = 'exec command test';
+        jest
+          .spyOn(execShell, 'execAsync')
+          .mockResolvedValue({stdout: testString, stderr: 'error'});
+
+        const config = {command: 'sanity check command'};
+        const inputs = [
+          {
+            timestamp: '2020-01-01T00:00:00Z',
+            duration: 3600,
+          },
+        ];
+
+        const {execute} = ShellExecCommand();
+        await expect(execute(inputs, config)).resolves.toEqual([
+          {
+            timestamp: '2020-01-01T00:00:00Z',
+            duration: 3600,
+            stdout: testString,
+          },
+        ]);
+      });
+
+      it('does not write anything to input if command exits with an error', async () => {
+        jest
+          .spyOn(execShell, 'execAsync')
+          .mockRejectedValue(new Error('error executing command'));
+        const log = jest.spyOn(console, 'log');
+
+        const config = {command: ''};
+        const inputs = [
+          {
+            timestamp: '2020-01-01T00:00:00Z',
+            duration: 3600,
+          },
+        ];
+
+        const {execute} = ShellExecCommand();
+        const result = await execute(inputs, config);
+        expect(log).toHaveBeenCalledWith(
+          'Error running the command: Error: error executing command'
+        );
+        expect(result).toEqual([
+          {
+            timestamp: '2020-01-01T00:00:00Z',
+            duration: 3600,
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,6 +2,7 @@ export {AzureImporter} from './azure-importer';
 export {BoaviztaCloudOutput, BoaviztaCpuOutput} from './boavizta';
 export {CloudCarbonFootprint} from './ccf';
 export {Co2js} from './co2js';
+export {ShellExecCommand} from './shell-exec-command';
 export {TeadsAWS} from './teads-aws';
 export {TeadsCurve} from './teads-curve';
 export {WattTimeGridEmissions} from './watt-time';

--- a/src/lib/shell-exec-command/README.md
+++ b/src/lib/shell-exec-command/README.md
@@ -1,0 +1,79 @@
+# ExecShellCommand
+
+> [!NOTE] > `ShellExecCommand` is a community plugin and not part of the IF standard library. This means the IF core team are not closely monitoring these plugins to keep them up to date. You should do your own research before implementing them!
+
+The `ShellExecCommand` plugin allows you to run shell commands from within your manifest file. This can be useful for running scripts or other commands that are not natively supported by IF.
+
+# Parameters
+
+## config
+
+- `command`: The shell command to be executed.
+
+## observations
+
+No input values.
+
+## Returns
+
+- `stdout`: The standard output of the command if it exited with successfully.
+-
+In case of exit codes other than 0, nothing is written to input and a log message with the error is written to the console.
+
+## Manifest
+
+The following is an example of how `ShellExecCommand` can be invoked using a manifest.
+
+```yaml
+name: exec-shell-command-demo
+description: example manifest invoking exec-shell-command
+tags:
+initialize:
+  outputs:
+    - yaml
+  plugins:
+    exec-command:
+      method: ShellExecCommand
+      path: '@grnsft/if-unofficial-plugins'
+tree:
+  children:
+    child:
+      pipeline:
+        - exec-command
+      config:
+        exec-command:
+          command: 'echo "Hello, World!"'
+      inputs:
+        - timestamp: 2024-02-25T00:00
+          duration: 1
+```
+
+This will produce an output like this:
+
+```yaml
+name: exec-shell-command-demo
+description: example manifest invoking exec-shell-command
+tags:
+initialize:
+  outputs:
+    - yaml
+  plugins:
+    exec-command:
+      method: ShellExecCommand
+      path: '@grnsft/if-unofficial-plugins'
+tree:
+  children:
+    child:
+      pipeline:
+        - exec-command
+      config:
+        exec-command:
+          command: 'echo "Hello, World!"'
+      inputs:
+        - timestamp: 2024-02-25T00:00
+          duration: 1
+      outputs:
+        - timestamp: 2024-02-25T00:00
+          duration: 1
+          stdout: Hello, World!
+```

--- a/src/lib/shell-exec-command/index.ts
+++ b/src/lib/shell-exec-command/index.ts
@@ -1,0 +1,50 @@
+import {exec} from 'child_process';
+import {z} from 'zod';
+
+import {PluginInterface} from '../../interfaces';
+import {ConfigParams, PluginParams} from '../../types';
+
+import {validate} from '../../util/validations';
+import * as util from 'util';
+
+export const execAsync = util.promisify(exec);
+
+export const ShellExecCommand = (): PluginInterface => {
+  const metadata = {
+    kind: 'execute',
+  };
+
+  /**
+   * Execute the command for a list of inputs.
+   */
+  const execute = async (inputs: PluginParams[], config?: ConfigParams) => {
+    const {command} = validateConfig(config);
+    return await Promise.all(
+      inputs.map(async input => {
+        try {
+          const {stdout} = await execAsync(command);
+          return {...input, stdout: stdout.trim()};
+        } catch (error) {
+          console.log(`Error running the command: ${error}`);
+          return input;
+        }
+      })
+    );
+  };
+
+  /**
+   * Checks for required fields in input.
+   */
+  const validateConfig = (config?: ConfigParams) => {
+    const schema = z.object({
+      command: z.string(),
+    });
+
+    return validate<z.infer<typeof schema>>(schema, config);
+  };
+
+  return {
+    metadata,
+    execute,
+  };
+};


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
A plugin that can execute shell commands that are provided in the manifest file.

Can be handy in certain situations, example see the `README.md` in #52.

